### PR TITLE
v2.0.3 - fixed links not being populated due to aws class name changes for account name

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# V2.0.3 (03/30/2024)
+
+- Fixed Issue: Cotainer Tab and Window links not showing up as AWS changed the class name for account name.
+  
 # V2.0.2 (03/30/2024)
 
 - Fixed Issue: Tab and Windows links not showing up when using search feature.

--- a/content.js
+++ b/content.js
@@ -197,7 +197,7 @@ function extractLoginLinks_And_Add_Tab_And_Window_Urls() {
       const account_nameContainer = element.closest('.stw1bkrahhh9wPMNiZKU');
       
       // Find the <strong> element with the appropriate class within the parent container
-      const account_name_element = account_nameContainer.querySelector('.awsui_root_18wu0_1qbfe_99');
+      const account_name_element = account_nameContainer.querySelector('strong');
 
       // Extract account name from the found element
       const account_name = account_name_element ? account_name_element.textContent.trim() : '';

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "homepage_url": "https://github.com/penchala-services-inc/aws-login-helper-firefox",
   "author": "Pechala Services Inc.",
   "name": "AWS Login Helper",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "permissions": ["cookies","*://*.awsapps.com/*","*://*.console.aws.amazon.com/*","activeTab", "storage", "contextualIdentities","tabs"],
   
   "content_scripts": [


### PR DESCRIPTION
Changed account name finding class to strong from dynamic class name that aws keep changing